### PR TITLE
Document translate_wanted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,29 @@ curl -X POST http://localhost:5000/translate_srt -H "Content-Type: application/j
 - Response:
 ```json
 {
-    "translated_files": [
+"translated_files": [
         "/media/Filmes/Exterminador do Futuro/pt-BR.srt",
         "/media/Filmes/Exterminador do Futuro/es.srt"
     ]
+}
+```
+
+### Translate Wanted Subtitles
+
+Use the `/translate_wanted` endpoint to automatically translate all subtitles
+marked as "wanted" in your Bazarr instance.
+
+Required environment variables:
+
+- `BAZARR_URL` – the base URL of your Bazarr API
+- `BAZARR_API_KEY` – your Bazarr API key
+
+Example request:
+
+```bash
+curl -X POST http://localhost:5000/translate_wanted -H "Content-Type: application/json" -d '{
+    "target_langs": ["PT-BR"],
+    "source_lang": "EN"
 }
 ```
 


### PR DESCRIPTION
## Summary
- add documentation for the `/translate_wanted` endpoint
- list BAZARR_URL and BAZARR_API_KEY environment variables
- show example curl request

## Testing
- `python3 -m compileall -q app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852e7ff12e48326abd718168f9a5963