### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/


### PR DESCRIPTION
## Summary
- prevent Python caches from being tracked with a project-level `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e804a510832688615e1028b876e8