### PR TITLE
Fix language extension handling

### DIFF
--- a/app/srt_utils.py
+++ b/app/srt_utils.py
@@ -1,6 +1,10 @@
 import os
 from translation import translate_text
-from language_utils import get_file_extension, get_language_code_from_extension
+from language_utils import (
+    get_file_extension,
+    get_language_code_from_extension,
+)
+from supported_languages import LANGUAGES
 
 def translate_srt_files(folder_path, target_langs, source_lang=None):
     translated_files = []
@@ -28,8 +32,17 @@ def translate_srt_files(folder_path, target_langs, source_lang=None):
                 with open(file_path, 'r', encoding='utf-8') as file:
                     content = file.read()
 
+                base = srt_file
+                for lang in LANGUAGES.values():
+                    if srt_file.endswith(lang["extension"]):
+                        base = srt_file[: -len(lang["extension"])]
+                        break
+                else:
+                    if srt_file.endswith(".srt"):
+                        base = srt_file[:-4]
+
                 translated_file_path = os.path.join(
-                    dirpath, f"{os.path.splitext(srt_file)[0]}.{target_lang}.srt"
+                    dirpath, f"{base}.{target_lang}.srt"
                 )
                 with open(translated_file_path, 'w', encoding='utf-8') as file:
                     file.write(translate_text(content, source_lang, target_lang))

--- a/tests/test_srt_utils.py
+++ b/tests/test_srt_utils.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app')))
+
+import srt_utils
+
+
+def create_srt_file(path, name, content="1\n00:00:00,000 --> 00:00:02,000\nHello"):
+    file_path = Path(path) / name
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+def test_output_filename_without_language_extension(tmp_path):
+    create_srt_file(tmp_path, "movie.en.srt")
+    with patch.object(srt_utils, "translate_text", return_value="translated"):
+        results = srt_utils.translate_srt_files(str(tmp_path), ["FR"], source_lang="EN")
+
+    expected = tmp_path / "movie.FR.srt"
+    assert str(expected) in results
+    assert expected.read_text(encoding="utf-8") == "translated"
+
+
+def test_output_filename_basic(tmp_path):
+    create_srt_file(tmp_path, "show.srt")
+    with patch.object(srt_utils, "translate_text", return_value="translated"):
+        results = srt_utils.translate_srt_files(str(tmp_path), ["ES"], source_lang="EN")
+
+    expected = tmp_path / "show.ES.srt"
+    assert str(expected) in results
+    assert expected.read_text(encoding="utf-8") == "translated"


### PR DESCRIPTION
## Summary
- properly strip any known language-specific extension before creating a translated subtitle
- cover `translate_srt_files` with tests for output file names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e7fcecd08326982c914f1e251871