### PR TITLE
Add PT-BR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ docker-compose up
     "PL": {"name": "Polish", "extension": ".pl.srt"},
     "RU": {"name": "Russian", "extension": ".ru.srt"},
     "PT": {"name": "Portuguese", "extension": ".pt.srt"},
+    "PT-BR": {"name": "Brazilian Portuguese", "extension": ".pt-br.srt"},
     "JA": {"name": "Japanese", "extension": ".ja.srt"},
     "ZH": {"name": "Chinese", "extension": ".zh.srt"},
     "DA": {"name": "Danish", "extension": ".da.srt"},

--- a/app/language_utils.py
+++ b/app/language_utils.py
@@ -4,6 +4,7 @@ def get_file_extension(language_code):
     return LANGUAGES.get(language_code, {}).get("extension", f".{language_code.lower()}.srt")
 
 def get_language_code_from_extension(file_name):
+    file_name = file_name.lower()
     for language_code, info in LANGUAGES.items():
         if file_name.endswith(info["extension"]):
             return language_code

--- a/app/srt_utils.py
+++ b/app/srt_utils.py
@@ -16,7 +16,7 @@ def translate_srt_files(folder_path, target_langs, source_lang=None):
             target_file_extension = get_file_extension(target_lang)
 
             for srt_file in existing_srt_files:
-                if srt_file.endswith(target_file_extension):
+                if srt_file.lower().endswith(target_file_extension):
                     continue
 
                 source_lang = source_lang or get_language_code_from_extension(srt_file)
@@ -29,7 +29,7 @@ def translate_srt_files(folder_path, target_langs, source_lang=None):
                     content = file.read()
 
                 translated_file_path = os.path.join(
-                    dirpath, f"{os.path.splitext(srt_file)[0]}.{target_lang}.srt"
+                    dirpath, f"{os.path.splitext(srt_file)[0]}{target_file_extension}"
                 )
                 with open(translated_file_path, 'w', encoding='utf-8') as file:
                     file.write(translate_text(content, source_lang, target_lang))

--- a/app/supported_languages.py
+++ b/app/supported_languages.py
@@ -8,6 +8,7 @@ LANGUAGES = {
     "PL": {"name": "Polish", "extension": ".pl.srt"},
     "RU": {"name": "Russian", "extension": ".ru.srt"},
     "PT": {"name": "Portuguese", "extension": ".pt.srt"},
+    "PT-BR": {"name": "Brazilian Portuguese", "extension": ".pt-br.srt"},
     "JA": {"name": "Japanese", "extension": ".ja.srt"},
     "ZH": {"name": "Chinese", "extension": ".zh.srt"},
     "DA": {"name": "Danish", "extension": ".da.srt"},


### PR DESCRIPTION
## Summary
- support PT-BR subtitle translation
- make extension detection case-insensitive
- use language-specific extension when writing translated files
- document PT-BR in README

## Testing
- `python3 -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e7fc09348326a4326f983c9e6e76