### PR TITLE
Improve translation error handling

### DIFF
--- a/app/translation.py
+++ b/app/translation.py
@@ -12,9 +12,11 @@ def translate_text(text, source_lang, target_lang):
         'target_lang': target_lang
     }
 
-    response = requests.post(url, data=params)
-    if response.status_code != 200:
-        raise Exception(f'Translation error: {response.text}')
+    try:
+        response = requests.post(url, data=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f'Translation error: {e}') from e
 
     translation = response.json()
     return translation['translations'][0]['text']


### PR DESCRIPTION
## Summary
- add a timeout for calls to DeepL API
- raise `RuntimeError` on translation failure

## Testing
- `pylint $(git ls-files '*.py') | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6852e7f9aa20832692be312fd778e687